### PR TITLE
Wojciech mat/token persistance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ tmp/
 tmp
 
 concat.conf
+
+notes.py

--- a/frontend/lib/app/config/app_router.dart
+++ b/frontend/lib/app/config/app_router.dart
@@ -9,6 +9,7 @@ import 'package:resellio/presentation/main_page/main_layout.dart';
 import 'package:resellio/presentation/common_widgets/adaptive_navigation.dart';
 import 'package:resellio/presentation/events/pages/event_details_page.dart';
 import 'package:resellio/presentation/cart/pages/cart_page.dart';
+import 'package:resellio/core/models/user_model.dart';
 import 'package:resellio/presentation/admin/pages/admin_dashboard_page.dart';
 import 'package:resellio/presentation/organizer/pages/create_event_page.dart';
 import 'package:resellio/presentation/organizer/pages/edit_event_page.dart';

--- a/frontend/lib/core/models/user_model.dart
+++ b/frontend/lib/core/models/user_model.dart
@@ -1,5 +1,45 @@
 import 'package:equatable/equatable.dart';
 
+class UserModel {
+  final int userId;
+  final String email;
+  final String name;
+  final UserRole role;
+  final int roleId;
+
+  UserModel({
+    required this.userId,
+    required this.email,
+    required this.name,
+    required this.role,
+    required this.roleId,
+  });
+
+  factory UserModel.fromJwt(Map<String, dynamic> jwtData) {
+    UserRole role;
+    switch (jwtData['role']) {
+      case 'organizer':
+        role = UserRole.organizer;
+        break;
+      case 'administrator':
+        role = UserRole.admin;
+        break;
+      default:
+        role = UserRole.customer;
+    }
+
+    return UserModel(
+      userId: jwtData['user_id'],
+      email: jwtData['sub'],
+      name: jwtData['name'] ?? 'User',
+      role: role,
+      roleId: jwtData['role_id'],
+    );
+  }
+}
+
+enum UserRole { customer, organizer, admin }
+
 class UserProfile extends Equatable {
   final int userId;
   final String email;

--- a/frontend/lib/core/network/api_client.dart
+++ b/frontend/lib/core/network/api_client.dart
@@ -3,8 +3,6 @@ import 'package:flutter/foundation.dart';
 import 'package:resellio/core/network/api_exception.dart';
 import 'package:resellio/core/services/storage_service.dart';
 
-import 'dart:html' as html show window;
-
 class ApiClient {
   final Dio _dio;
   String? _authToken;

--- a/frontend/lib/core/network/api_client.dart
+++ b/frontend/lib/core/network/api_client.dart
@@ -1,6 +1,7 @@
 import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
 import 'package:resellio/core/network/api_exception.dart';
+import 'package:resellio/core/services/storage_service.dart';
 
 import 'dart:html' as html show window;
 
@@ -22,7 +23,7 @@ class ApiClient {
 
   void _loadStoredToken() {
     if (kIsWeb) {
-      _authToken = html.window.localStorage[_tokenKey];
+      _authToken = StorageService.instance.getItem(_tokenKey);
     }
   }
 
@@ -30,9 +31,9 @@ class ApiClient {
     _authToken = token;
     if (kIsWeb) {
       if (token != null) {
-        html.window.localStorage[_tokenKey] = token;
+        StorageService.instance.setItem(_tokenKey, token);
       } else {
-        html.window.localStorage.remove(_tokenKey);
+        StorageService.instance.removeItem(_tokenKey);
       }
     }
   }

--- a/frontend/lib/core/services/auth_service.dart
+++ b/frontend/lib/core/services/auth_service.dart
@@ -1,8 +1,9 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'dart:html' as html;
 import 'package:resellio/core/models/models.dart';
 import 'package:resellio/core/repositories/repositories.dart';
 import 'package:resellio/core/utils/jwt_decoder.dart';
+import 'package:resellio/core/services/storage_service.dart';
 import 'package:resellio/presentation/common_widgets/adaptive_navigation.dart';
 
 
@@ -25,7 +26,7 @@ class AuthService extends ChangeNotifier {
 
   Future<void> _loadStoredToken() async {
     try {
-      final storedToken = html.window.localStorage[_tokenKey];
+      final storedToken = StorageService.instance.getItem(_tokenKey);
       if (storedToken != null && storedToken.isNotEmpty) {
         final jwtData = tryDecodeJwt(storedToken);
         if (jwtData != null) {
@@ -47,7 +48,6 @@ class AuthService extends ChangeNotifier {
             }
           }
         }
-
         await _clearStoredToken();
       }
     } catch (e) {
@@ -57,11 +57,11 @@ class AuthService extends ChangeNotifier {
   }
 
   void _storeToken(String token) {
-    html.window.localStorage[_tokenKey] = token;
+    StorageService.instance.setItem(_tokenKey, token);
   }
 
   Future<void> _clearStoredToken() async {
-    html.window.localStorage.remove(_tokenKey);
+    StorageService.instance.removeItem(_tokenKey);
     _token = null;
     _user = null;
     _detailedProfile = null;

--- a/frontend/lib/core/services/auth_service.dart
+++ b/frontend/lib/core/services/auth_service.dart
@@ -5,42 +5,6 @@ import 'package:resellio/core/repositories/repositories.dart';
 import 'package:resellio/core/utils/jwt_decoder.dart';
 import 'package:resellio/presentation/common_widgets/adaptive_navigation.dart';
 
-class UserModel {
-  final int userId;
-  final String email;
-  final String name;
-  final UserRole role;
-  final int roleId;
-
-  UserModel(
-      {required this.userId,
-      required this.email,
-      required this.name,
-      required this.role,
-      required this.roleId});
-
-  factory UserModel.fromJwt(Map<String, dynamic> jwtData) {
-    UserRole role;
-    switch (jwtData['role']) {
-      case 'organizer':
-        role = UserRole.organizer;
-        break;
-      case 'administrator':
-        role = UserRole.admin;
-        break;
-      default:
-        role = UserRole.customer;
-    }
-
-    return UserModel(
-      userId: jwtData['user_id'],
-      email: jwtData['sub'],
-      name: jwtData['name'] ?? 'User',
-      role: role,
-      roleId: jwtData['role_id'],
-    );
-  }
-}
 
 class AuthService extends ChangeNotifier {
   final AuthRepository _authRepository;

--- a/frontend/lib/core/services/storage_service.dart
+++ b/frontend/lib/core/services/storage_service.dart
@@ -1,0 +1,11 @@
+import 'storage_service_stub.dart'
+    if (dart.library.html) 'storage_service_web.dart'
+    if (dart.library.io) 'storage_service_io.dart';
+
+abstract class StorageService {
+  static StorageService get instance => getStorageService();
+
+  String? getItem(String key);
+  void setItem(String key, String value);
+  void removeItem(String key);
+}

--- a/frontend/lib/core/services/storage_service_io.dart
+++ b/frontend/lib/core/services/storage_service_io.dart
@@ -1,0 +1,14 @@
+import 'storage_service.dart';
+
+class IoStorageService implements StorageService {
+  @override
+  String? getItem(String key) => null;
+
+  @override
+  void setItem(String key, String value) {}
+
+  @override
+  void removeItem(String key) {}
+}
+
+StorageService getStorageService() => IoStorageService();

--- a/frontend/lib/core/services/storage_service_stub.dart
+++ b/frontend/lib/core/services/storage_service_stub.dart
@@ -1,0 +1,14 @@
+import 'storage_service.dart';
+
+class StubStorageService implements StorageService {
+  @override
+  String? getItem(String key) => null;
+
+  @override
+  void setItem(String key, String value) {}
+
+  @override
+  void removeItem(String key) {}
+}
+
+StorageService getStorageService() => StubStorageService();

--- a/frontend/lib/core/services/storage_service_web.dart
+++ b/frontend/lib/core/services/storage_service_web.dart
@@ -1,0 +1,15 @@
+import 'dart:html' as html;
+import 'storage_service.dart';
+
+class WebStorageService implements StorageService {
+  @override
+  String? getItem(String key) => html.window.localStorage[key];
+
+  @override
+  void setItem(String key, String value) => html.window.localStorage[key] = value;
+
+  @override
+  void removeItem(String key) => html.window.localStorage.remove(key);
+}
+
+StorageService getStorageService() => WebStorageService();

--- a/frontend/lib/core/utils/jwt_decoder.dart
+++ b/frontend/lib/core/utils/jwt_decoder.dart
@@ -14,3 +14,24 @@ Map<String, dynamic>? tryDecodeJwt(String token) {
     return null;
   }
 }
+
+bool isTokenExpired(String token) {
+  final jwtData = tryDecodeJwt(token);
+  if (jwtData == null) return true;
+
+  final exp = jwtData['exp'];
+  if (exp == null) return true;
+
+  final expiryDate = DateTime.fromMillisecondsSinceEpoch(exp * 1000);
+  return expiryDate.isBefore(DateTime.now());
+}
+
+DateTime? getTokenExpiry(String token) {
+  final jwtData = tryDecodeJwt(token);
+  if (jwtData == null) return null;
+
+  final exp = jwtData['exp'];
+  if (exp == null) return null;
+
+  return DateTime.fromMillisecondsSinceEpoch(exp * 1000);
+}

--- a/frontend/lib/main.dart
+++ b/frontend/lib/main.dart
@@ -57,11 +57,42 @@ void main() {
   );
 }
 
-class ResellioApp extends StatelessWidget {
+class ResellioApp extends StatefulWidget {
   const ResellioApp({super.key});
 
   @override
+  State<ResellioApp> createState() => _ResellioAppState();
+}
+
+class _ResellioAppState extends State<ResellioApp> {
+  bool _isInitialized = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _initializeAuth();
+  }
+
+  Future<void> _initializeAuth() async {
+    // Wait for AuthService to potentially load stored token
+    await Future.microtask(() {});
+    if (mounted) {
+      setState(() {
+        _isInitialized = true;
+      });
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
+    if (!_isInitialized) {
+      return MaterialApp(
+        home: Scaffold(
+          body: Center(child: CircularProgressIndicator()),
+        ),
+      );
+    }
+
     final authService = Provider.of<AuthService>(context);
 
     return MaterialApp.router(

--- a/frontend/lib/presentation/common_widgets/adaptive_navigation.dart
+++ b/frontend/lib/presentation/common_widgets/adaptive_navigation.dart
@@ -10,8 +10,7 @@ import 'package:resellio/presentation/organizer/pages/organizer_dashboard_page.d
 import 'package:resellio/presentation/admin/pages/admin_dashboard_page.dart';
 import 'package:resellio/presentation/organizer/pages/organizer_events_page.dart';
 import 'package:resellio/presentation/organizer/pages/organizer_stats_page.dart';
-
-enum UserRole { customer, organizer, admin }
+import 'package:resellio/core/models/user_model.dart';
 
 class AdaptiveNavigation extends StatefulWidget {
   final UserRole userRole;

--- a/frontend/lib/presentation/main_page/main_layout.dart
+++ b/frontend/lib/presentation/main_page/main_layout.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:resellio/core/services/auth_service.dart';
+import 'package:resellio/core/models/user_model.dart';
 import 'package:resellio/presentation/common_widgets/adaptive_navigation.dart';
 
 class MainLayout extends StatelessWidget {

--- a/frontend/lib/presentation/profile/pages/profile_page.dart
+++ b/frontend/lib/presentation/profile/pages/profile_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:provider/provider.dart';
 import 'package:resellio/core/repositories/repositories.dart';
 import 'package:resellio/core/services/auth_service.dart';
+import 'package:resellio/core/models/user_model.dart';
 import 'package:resellio/presentation/common_widgets/adaptive_navigation.dart';
 import 'package:resellio/presentation/common_widgets/bloc_state_wrapper.dart';
 import 'package:resellio/presentation/common_widgets/dialogs.dart';


### PR DESCRIPTION
## JWT Token Persistence with localStorage

**Problem:** Users were logged out after every page refresh because JWT tokens were only stored in memory.

**Solution:** 
- Added localStorage support to persist JWT tokens across browser sessions
- Implemented automatic token validation and expiry checking on app initialization
- Enhanced AuthService to load stored tokens on startup and clear expired tokens
- Added web-only conditional imports to support localStorage functionality

**Key Changes:**
- `AuthService`: Added token persistence methods with automatic loading/clearing
- `ApiClient`: Enhanced to use stored tokens and sync with localStorage
- `UserModel`: Added UserModel class and UserRole enum
- `main.dart`: Added initialization flow to wait for token loading
- `jwt_decoder.dart`: Added token expiry validation utilities

**Benefits:**
- Users stay logged in after page refresh
- Automatic cleanup of expired tokens
- Better user experience with persistent authentication
- Web-safe implementation with fallback for non-web platforms