### PR TITLE
Remove Profile Saved Successfully

### DIFF
--- a/frontend/lib/presentation/profile/cubit/profile_cubit.dart
+++ b/frontend/lib/presentation/profile/cubit/profile_cubit.dart
@@ -39,7 +39,7 @@ class ProfileCubit extends Cubit<ProfileState> {
     try {
       final updatedProfile = await _userRepository.updateUserProfile(data);
       _authService.updateDetailedProfile(updatedProfile);
-      emit(ProfileLoaded(userProfile: updatedProfile));
+      emit(ProfileSaved(userProfile: updatedProfile));
     } on ApiException catch (e) {
       emit(ProfileUpdateError(
           userProfile: loadedState.userProfile, message: e.message));

--- a/frontend/lib/presentation/profile/cubit/profile_state.dart
+++ b/frontend/lib/presentation/profile/cubit/profile_state.dart
@@ -1,6 +1,10 @@
 import 'package:equatable/equatable.dart';
 import 'package:resellio/core/models/models.dart';
 
+class ProfileSaved extends ProfileLoaded {
+  const ProfileSaved({required super.userProfile}) : super(isEditing: false);
+}
+
 abstract class ProfileState extends Equatable {
   const ProfileState();
   @override

--- a/frontend/lib/presentation/profile/pages/profile_page.dart
+++ b/frontend/lib/presentation/profile/pages/profile_page.dart
@@ -73,9 +73,7 @@ class _ProfileView extends StatelessWidget {
       ],
       body: BlocListener<ProfileCubit, ProfileState>(
         listener: (context, state) {
-          if (state is ProfileLoaded &&
-              !state.isEditing &&
-              state is! ProfileSaving) {
+          if (state is ProfileSaved) {
             ScaffoldMessenger.of(context)
               ..hideCurrentSnackBar()
               ..showSnackBar(


### PR DESCRIPTION
## Remove Profile Saved Successfully Notification

**Problem:**
The "Profile saved successfully!" message was showing up every time the profile page loaded, not just when the user actually saved changes.

**Solution:**
- Added a new `ProfileSaved` state that only triggers when profile is actually saved
- Updated the listener to only show success message for `ProfileSaved` state instead of any `ProfileLoaded` state

**Changes:**
- `profile_state.dart`: Added `ProfileSaved` state class
- `profile_cubit.dart`: Emit `ProfileSaved` instead of `ProfileLoaded` after successful update
- `profile_page.dart`: Listen for `ProfileSaved` state only

**Result:**
Success message now only appears when user actually saves profile changes, not on every page load.