### PR TITLE
Delete single filter button

### DIFF
--- a/frontend/lib/presentation/events/pages/event_browse_page.dart
+++ b/frontend/lib/presentation/events/pages/event_browse_page.dart
@@ -353,7 +353,31 @@ class _EventBrowseViewState extends State<_EventBrowseView> {
                             label: Text('Location: ${_currentFilters.location}'),
                             onDeleted: () {
                               setState(() {
-                                _currentFilters = _currentFilters.copyWith(location: null);
+                                _currentFilters = EventFilterModel(
+                                  name: _currentFilters.name,
+                                  startDateFrom: _currentFilters.startDateFrom,
+                                  startDateTo: _currentFilters.startDateTo,
+                                  minPrice: _currentFilters.minPrice,
+                                  maxPrice: _currentFilters.maxPrice,
+                                );
+                                _currentPage = 1;
+                                _hasMoreData = true;
+                              });
+                              _loadEventsWithFilters(reset: true);
+                            },
+                          ),
+                        if (_currentFilters.startDateFrom != null || _currentFilters.startDateTo != null)
+                          Chip(
+                            label: const Text('Date Range'),
+                            onDeleted: () {
+                              setState(() {
+                                _currentFilters = EventFilterModel(
+                                  name: _currentFilters.name,
+                                  location: _currentFilters.location,
+                                  minPrice: _currentFilters.minPrice,
+                                  maxPrice: _currentFilters.maxPrice,
+                                  // startDateFrom and startDateTo are set to null
+                                );
                                 _currentPage = 1;
                                 _hasMoreData = true;
                               });
@@ -367,9 +391,12 @@ class _EventBrowseViewState extends State<_EventBrowseView> {
                             ),
                             onDeleted: () {
                               setState(() {
-                                _currentFilters = _currentFilters.copyWith(
-                                  minPrice: null,
-                                  maxPrice: null,
+                                _currentFilters = EventFilterModel(
+                                  name: _currentFilters.name,
+                                  location: _currentFilters.location,
+                                  startDateFrom: _currentFilters.startDateFrom,
+                                  startDateTo: _currentFilters.startDateTo,
+                                  // minPrice and maxPrice are set to null
                                 );
                                 _currentPage = 1;
                                 _hasMoreData = true;


### PR DESCRIPTION
## Delete single filter button functionality

Implements working delete ("x") buttons for individual filter chips on the Events Discovery page.

**Changes:**
- Added `onDeleted` callbacks to Location, Date Range, and Price filter chips
- Replaced `copyWith()` calls with explicit `EventFilterModel` constructors to ensure proper filter removal
- Each delete button now properly clears its specific filter while preserving other active filters
- Maintains pagination state reset and triggers event reload after filter removal

**Fixes:** Filter chips now have functional delete buttons that actually remove the applied filters instead of being non-interactive.